### PR TITLE
Full set of CEA-861 speaker layouts available to hdmi

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_audio.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_audio.c
@@ -61,9 +61,9 @@ static void hdmi_tx_construct_aud_packet(
 	struct hdmitx_audpara *audio_param, unsigned char *AUD_DB,
 	unsigned char *CHAN_STAT_BUF, int hdmi_ch)
 {
-#ifndef PCM_USE_INFOFRAME
+#ifdef PCM_USE_INFOFRAME
 	if (audio_param->type == CT_PCM) {
-		hdmi_print(INF, AUD "Audio Type: PCM\n");
+		hdmi_print(INF, AUD "Audio Type: PCM\nAudio Channels: %u hdmi_ch %u\n",audio_param->channel_num, hdmi_ch);
 		if (AUD_DB) {
 			/*Note: HDMI Spec V1.4 Page 154*/
 			if ((audio_param->channel_num == CC_2CH) ||
@@ -225,12 +225,28 @@ int hdmitx_set_audio(struct hdmitx_dev *hdmitx_device,
 		AUD_DB[i] = 0;
 	for (i = 0; i < (24*2); i++)
 		CHAN_STAT_BUF[i] = 0;
+	// write speaker layout and parse hdmi_ch to aud_output_ch
+	if (hdmi_ch > 0){
+		hdmitx_device->speaker_layout = hdmi_ch;
+		if (hdmi_ch > 0x0b)
+			hdmitx_device->aud_output_ch = 8 << 4 | 0x0f;
+		else if (hdmi_ch > 0x03)
+			hdmitx_device->aud_output_ch = 6 << 4 | 0x07;
+		else if (hdmi_ch > 0x00)
+			hdmitx_device->aud_output_ch = 4 << 4 | 0x03;
+		else
+			hdmitx_device->aud_output_ch = 0; // or maybe 2 << 4 | 0x0f
+	}
+	else hdmitx_device->aud_output_ch = 0;
+
 	if (hdmitx_device->HWOp.SetAudMode(hdmitx_device,
 		audio_param) >= 0) {
 		hdmi_tx_construct_aud_packet(audio_param, AUD_DB,
 			CHAN_STAT_BUF, hdmi_ch);
-
-		hdmitx_device->HWOp.SetAudioInfoFrame(AUD_DB, CHAN_STAT_BUF);
+		hdmi_print(INF, AUD "Audio Output Channels: %x:%x\n",
+			(hdmitx_device->aud_output_ch >> 4) & 0xf,
+			(hdmitx_device->aud_output_ch & 0xf)); 
+		hdmitx_device->HWOp.SetAudioInfoFrame(AUD_DB, CHAN_STAT_BUF); // this does precisely nothing
 		ret = 0;
 	}
 #if 0

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_audio.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_audio.c
@@ -226,7 +226,7 @@ int hdmitx_set_audio(struct hdmitx_dev *hdmitx_device,
 	for (i = 0; i < (24*2); i++)
 		CHAN_STAT_BUF[i] = 0;
 	// write speaker layout and parse hdmi_ch to aud_output_ch
-	if (hdmi_ch > 0){
+	if (hdmi_ch > 0 && audio_param->channel_num > CC_2CH){
 		hdmitx_device->speaker_layout = hdmi_ch;
 		if (hdmi_ch > 0x0b)
 			hdmitx_device->aud_output_ch = 8 << 4 | 0x0f;
@@ -243,7 +243,7 @@ int hdmitx_set_audio(struct hdmitx_dev *hdmitx_device,
 		audio_param) >= 0) {
 		hdmi_tx_construct_aud_packet(audio_param, AUD_DB,
 			CHAN_STAT_BUF, hdmi_ch);
-		hdmi_print(INF, AUD "Audio Output Channels: %x:%x\n",
+		hdmi_print(INF, AUD "Audio Output Channels set to: %x:%x\n",
 			(hdmitx_device->aud_output_ch >> 4) & 0xf,
 			(hdmitx_device->aud_output_ch & 0xf)); 
 		hdmitx_device->HWOp.SetAudioInfoFrame(AUD_DB, CHAN_STAT_BUF); // this does precisely nothing

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_audio.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_audio.c
@@ -225,14 +225,13 @@ int hdmitx_set_audio(struct hdmitx_dev *hdmitx_device,
 		AUD_DB[i] = 0;
 	for (i = 0; i < (24*2); i++)
 		CHAN_STAT_BUF[i] = 0;
-	// write speaker layout and parse hdmi_ch to aud_output_ch
-	if (hdmi_ch > 0 && audio_param->channel_num > CC_2CH){
-		hdmitx_device->speaker_layout = hdmi_ch;
-		if (hdmi_ch > 0x0b)
+	// parse hdmitx_device->speaker_layout to aud_output_ch
+	if (hdmitx_device->speaker_layout > 0 && audio_param->channel_num > CC_2CH){
+		if (hdmitx_device->speaker_layout > 0x0b)
 			hdmitx_device->aud_output_ch = 8 << 4 | 0x0f;
-		else if (hdmi_ch > 0x03)
+		else if (hdmitx_device->speaker_layout > 0x03)
 			hdmitx_device->aud_output_ch = 6 << 4 | 0x07;
-		else if (hdmi_ch > 0x00)
+		else if (hdmitx_device->speaker_layout > 0x00)
 			hdmitx_device->aud_output_ch = 4 << 4 | 0x03;
 		else
 			hdmitx_device->aud_output_ch = 0; // or maybe 2 << 4 | 0x0f

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -2449,8 +2449,8 @@ static int hdmitx_notify_callback_a(struct notifier_block *block,
 
 	if (audio_param->type != cmd) {
 		hdmi_print(INF, AUD "aout notify format %s was %s\n",
-			aud_type_string[audio_param->type & 0xff],
-			aud_type_string[cmd & 0xff]);
+			aud_type_string[cmd & 0xff],
+			aud_type_string[audio_param->type & 0xff]);
 		audio_param->type = cmd;
 		hdmitx_device.audio_param_update_flag = 1;
 	}
@@ -2503,7 +2503,7 @@ static int hdmitx_notify_callback_a(struct notifier_block *block,
 			hdmitx_audio_mute_op(0);
 			hdmitx_set_audio(&hdmitx_device,
 			&(hdmitx_device.cur_audio_param), hdmitx_device.speaker_layout);
-			msleep(300);
+			// msleep(300); // this has no discernable effect on plops
 			hdmitx_audio_mute_op(1);
 		if ((hdmitx_device.audio_notify_flag == 1) ||
 			(hdmitx_device.audio_step == 1)) {

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2354,22 +2354,26 @@ static void set_aud_info_pkt(struct hdmitx_dev *hdev,
 			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x13);
 		else
 			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x00);
-		/* Refer to CEA861-D P90 */
-		switch (GET_OUTCHN_NO(hdev->aud_output_ch)) {
-		case 2:
-			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x00);
-			break;
-		case 4:
-			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x03);
-			break;
-		case 6:
-			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x0b);
-			break;
-		case 8:
-			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x13);
-			break;
-		default:
-			break;
+		if (hdev->speaker_layout >= 0)
+			hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, hdev->speaker_layout);
+		else {
+			/* Refer to CEA861-D P90 */
+			switch (GET_OUTCHN_NO(hdev->aud_output_ch)) {
+				case 2:
+					hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x00);
+					break;
+				case 4:
+					hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x03);
+					break;
+				case 6:
+					hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x0b);
+					break;
+				case 8:
+					hdmitx_wr_reg(HDMITX_DWC_FC_AUDICONF2, 0x13);
+					break;
+				default:
+					break;
+			}
 		}
 		break;
 	case CT_DTS:

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2534,7 +2534,7 @@ static int hdmitx_set_audmode(struct hdmitx_dev *hdev,
 		return 0;
 	if (!audio_param)
 		return 0;
-	pr_info("hdmtix: set audio %d\n", hdev->tx_aud_cfg);
+	pr_info("hdmtix: setting audio %d\n", hdev->tx_aud_cfg);
 	audio_mute_op(hdev->tx_aud_cfg);
 	/* PCM & 8 ch */
 	if ((audio_param->type == CT_PCM) &&

--- a/include/linux/amlogic/hdmi_tx/hdmi_tx_module.h
+++ b/include/linux/amlogic/hdmi_tx/hdmi_tx_module.h
@@ -280,6 +280,7 @@ struct hdmitx_dev {
 	/* configure for I2S: 8ch in, 2ch out */
 	/* 0: default setting  1:ch0/1  2:ch2/3  3:ch4/5  4:ch6/7 */
 	unsigned int aud_output_ch;
+	unsigned int speaker_layout;
 	unsigned int hdr_src_feature;
 	unsigned int flag_3dfp:1;
 	unsigned int flag_3dtb:1;

--- a/sound/soc/aml/m8/aml_audio_hw.c
+++ b/sound/soc/aml/m8/aml_audio_hw.c
@@ -1043,10 +1043,28 @@ void audio_i2s_swap_left_right(unsigned int flag)
 	aml_cbus_update_bits(AIU_I2S_MUTE_SWAP, 0x3 << 2, flag << 2);
 }
 
+void audio_i2s_set_channel_mask(unsigned int mask)
+{
+	aml_cbus_update_bits(AIU_I2S_MUTE_SWAP, 0xff << 8, mask << 8);
+}
+
 void audio_i2s_958_same_source(unsigned int same)
 {
 	aml_cbus_update_bits(AIU_I2S_MISC, 1 << 3, (!!same) << 3);
 }
+
+/* which channels go to DAC */
+unsigned int read_i2s_out_cfg(void)
+{
+	unsigned int val;
+	val = aml_read_cbus(AIU_I2S_OUT_CFG);
+	return val;
+}
+
+void audio_i2s_set_out_chs(unsigned int channels)
+{
+	aml_cbus_update_bits(AIU_I2S_OUT_CFG, 0xf, channels);
+}	
 
 void set_hw_resample_source(int source)
 {

--- a/sound/soc/aml/m8/aml_i2s_dai.c
+++ b/sound/soc/aml/m8/aml_i2s_dai.c
@@ -77,19 +77,43 @@ struct channel_speaker_allocation {
 static struct channel_speaker_allocation channel_allocations[] = {
 /*      	       channel:   7     6    5    4    3     2    1    0  */
 { .channels = 2,  .speakers = {  NA,   NA,  NA,  NA,  NA,   NA,  FR,  FL } },
-                                 /* 2.1 */
+                                 /* 2.1 CEA 0x01 */
 { .channels = 3,  .speakers = {  NA,   NA,  NA,  NA,  NA,  LFE,  FR,  FL } },
-                                 /* surround40 */
+                                 /* 3.0 CEA 0x02 */
+{ .channels = 3,  .speakers = {  NA,   NA,  NA,  NA,  FC,   NA,  FR,  FL } },
+                                 /* 3.1 CEA 0x03 */
+{ .channels = 4,  .speakers = {  NA,   NA,  NA,  NA,  FC,  LFE,  FR,  FL } },
+                                 /* 3.0 CEA 0x04 */
+{ .channels = 3,  .speakers = {  NA,   NA,  NA,  RC,  NA,   NA,  FR,  FL } },
+                                 /* 3.1 CEA 0x05 */
+{ .channels = 4,  .speakers = {  NA,   NA,  NA,  RC,  NA,  LFE,  FR,  FL } },
+                                 /* 4.0 CEA 0x06 */
+{ .channels = 4,  .speakers = {  NA,   NA,  NA,  RC,  FC,   NA,  FR,  FL } },
+                                 /* 4.1 CEA 0x07 */
+{ .channels = 5,  .speakers = {  NA,   NA,  NA,  RC,  FC,  LFE,  FR,  FL } },
+                                 /* surround40 CEA 0x08 */
 { .channels = 4,  .speakers = {  NA,   NA,  RR,  RL,  NA,   NA,  FR,  FL } },
-                                 /* surround41 */
+                                 /* surround41 CEA 0x09 */
 { .channels = 5,  .speakers = {  NA,   NA,  RR,  RL,  NA,  LFE,  FR,  FL } },
-                                 /* surround50 */
+                                 /* surround50 CEA 0x0a */
 { .channels = 5,  .speakers = {  NA,   NA,  RR,  RL,  FC,   NA,  FR,  FL } },
-                                 /* surround51 */
+                                 /* surround51 CEA 0x0b */
 { .channels = 6,  .speakers = {  NA,   NA,  RR,  RL,  FC,  LFE,  FR,  FL } },
-                                 /* 6.1 */
-{ .channels = 7,  .speakers = {  NA,   RC,  RR,  RL,  FC,  LFE,  FR,  FL } },
-                                 /* surround71 */
+                                 /* 5.0 CEA 0x0c */
+{ .channels = 5,  .speakers = {  NA,   RC, RRC, RLC,  NA,   NA,  FR,  FL } },
+                                 /* 5.1 CEA 0x0d */
+{ .channels = 6,  .speakers = {  NA,   RC, RRC, RLC,  NA,  LFE,  FR,  FL } },
+                                 /* 6.0 CEA 0x0e */
+{ .channels = 6,  .speakers = {  NA,   RC, RRC, RLC,  FC,   NA,  FR,  FL } },
+                                 /* 6.1 CEA 0x0f*/
+{ .channels = 7,  .speakers = {  NA,   RC, RRC, RLC,  FC,  LFE,  FR,  FL } },
+                                 /* 6.0 CEA 0x10*/
+{ .channels = 6,  .speakers = { RRC,  RLC,  RR,  RL,  NA,   NA,  FR,  FL } },
+                                 /* 6.1 CEA 0x11*/
+{ .channels = 7,  .speakers = { RRC,  RLC,  RR,  RL,  NA,  LFE,  FR,  FL } },
+                                 /* 7.0 CEA 0x12*/
+{ .channels = 7,  .speakers = { RRC,  RLC,  RR,  RL,  FC,   NA,  FR,  FL } },
+                                 /* surround71 CEA 0x13 */
 { .channels = 8,  .speakers = { RRC,  RLC,  RR,  RL,  FC,  LFE,  FR,  FL } },
 };
 

--- a/sound/soc/aml/m8/aml_i2s_dai.c
+++ b/sound/soc/aml/m8/aml_i2s_dai.c
@@ -149,6 +149,18 @@ static void aml_hw_i2s_init(struct snd_pcm_runtime *runtime)
 			 runtime->channels);
 }
 
+static int get_speaker_mask(struct snd_pcm_runtime *runtime)
+{
+	struct aml_runtime_data *prtd = (struct aml_runtime_data *)runtime->private_data;
+	int speaker_mask = 0;
+	for (int i=0; i<8; i++)
+	{
+		if (strstr(channel_allocations[prtd->chmap_layout].speakers[i], "NA")==NULL)
+			speaker_mask |= 1 << (7-i);
+	}
+	return speaker_mask;
+}
+
 static int aml_dai_i2s_chmap_ctl_tlv(struct snd_kcontrol *kcontrol, int op_flag,
                                      unsigned int size, unsigned int __user *tlv)
 {


### PR DESCRIPTION
Added all CEA-861-D layouts to i2s driver.
Added setting speaker layout from sysfs
hdmi audio setup now uses speaker layout to set channel mask