### PR TITLE
Don't force 8 bits when deep colour is not advertised.

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -652,7 +652,6 @@ static int set_disp_mode_auto(void)
 			if (! dc_support){
 				pr_warn("Bitdepth is set to %d bits but display does not support deep colour",
 						hdev->cur_video_param->color_depth * 2);
-				hdev->cur_video_param->color_depth = COLORDEPTH_24B;
 			}
 		}
 	}


### PR DESCRIPTION
User reports Cambridge Audio soundbar does not pass on deep colour caps. This should fix it.