### PR TITLE
Bugfix in parsing 3D modes and disp_cap_3d

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_common/hdmi_parameters.c
+++ b/drivers/amlogic/hdmi/hdmi_common/hdmi_parameters.c
@@ -650,10 +650,74 @@ static struct hdmi_format_para fmt_para_720x480p60_16x9 = {
 	},
 };
 
+static struct hdmi_format_para fmt_para_720x480p60_4x3 = {
+	.vic = HDMI_720x480p60_4x3,
+	.name = "720x480p60hz4x3",
+	.sname = "480p60hz4x3",
+	.pixel_repetition_factor = 0,
+	.progress_mode = 1,
+	.scrambler_en = 0,
+	.tmds_clk_div40 = 0,
+	.tmds_clk = 27027,
+	.timing = {
+		.pixel_freq = 27027,
+		.frac_freq = 27000,
+		.h_freq = 31469,
+		.v_freq = 59940,
+		.vsync_polarity = 0,
+		.hsync_polarity = 0,
+		.h_active = 720,
+		.h_total = 858,
+		.h_blank = 138,
+		.h_front = 16,
+		.h_sync = 62,
+		.h_back = 60,
+		.v_active = 480,
+		.v_total = 525,
+		.v_blank = 45,
+		.v_front = 9,
+		.v_sync = 6,
+		.v_back = 30,
+		.v_sync_ln = 7,
+	},
+};
+
 static struct hdmi_format_para fmt_para_720x480i60_16x9 = {
 	.vic = HDMI_720x480i60_16x9,
 	.name = "720x480i60hz",
 	.sname = "480i60hz",
+	.pixel_repetition_factor = 1,
+	.progress_mode = 0,
+	.scrambler_en = 0,
+	.tmds_clk_div40 = 0,
+	.tmds_clk = 27027,
+	.timing = {
+		.pixel_freq = 27027,
+		.frac_freq = 27000,
+		.h_freq = 15734,
+		.v_freq = 59940,
+		.vsync_polarity = 0,
+		.hsync_polarity = 0,
+		.h_active = 1440,
+		.h_total = 1716,
+		.h_blank = 276,
+		.h_front = 38,
+		.h_sync = 124,
+		.h_back = 114,
+		.v_active = 480/2,
+		.v_total = 525,
+		.v_blank = 45/2,
+		.v_front = 4,
+		.v_sync = 3,
+		.v_back = 15,
+		.v_sync_ln = 4,
+	},
+};
+
+static struct hdmi_format_para fmt_para_720x480i60_4x3 = {
+	.vic = HDMI_720x480i60_4x3,
+	.name = "720x480i60hz4x3",
+	.sname = "480i60hz4x3",
 	.pixel_repetition_factor = 1,
 	.progress_mode = 0,
 	.scrambler_en = 0,
@@ -713,10 +777,72 @@ static struct hdmi_format_para fmt_para_720x576p50_16x9 = {
 	},
 };
 
+static struct hdmi_format_para fmt_para_720x576p50_4x3 = {
+	.vic = HDMI_720x576p50_4x3,
+	.name = "720x576p50hz4x3",
+	.sname = "576p50hz4x3",
+	.pixel_repetition_factor = 0,
+	.progress_mode = 1,
+	.scrambler_en = 0,
+	.tmds_clk_div40 = 0,
+	.tmds_clk = 27000,
+	.timing = {
+		.pixel_freq = 27000,
+		.h_freq = 31250,
+		.v_freq = 50000,
+		.vsync_polarity = 0,
+		.hsync_polarity = 0,
+		.h_active = 720,
+		.h_total = 864,
+		.h_blank = 144,
+		.h_front = 12,
+		.h_sync = 64,
+		.h_back = 68,
+		.v_active = 576,
+		.v_total = 625,
+		.v_blank = 49,
+		.v_front = 5,
+		.v_sync = 5,
+		.v_back = 39,
+		.v_sync_ln = 1,
+	},
+};
+
 static struct hdmi_format_para fmt_para_720x576i50_16x9 = {
 	.vic = HDMI_720x576i50_16x9,
 	.name = "720x576i50hz",
 	.sname = "576i50hz",
+	.pixel_repetition_factor = 1,
+	.progress_mode = 0,
+	.scrambler_en = 0,
+	.tmds_clk_div40 = 0,
+	.tmds_clk = 27000,
+	.timing = {
+		.pixel_freq = 27000,
+		.h_freq = 15625,
+		.v_freq = 50000,
+		.vsync_polarity = 0,
+		.hsync_polarity = 0,
+		.h_active = 1440,
+		.h_total = 1728,
+		.h_blank = 288,
+		.h_front = 24,
+		.h_sync = 126,
+		.h_back = 138,
+		.v_active = 576/2,
+		.v_total = 625,
+		.v_blank = 49/2,
+		.v_front = 2,
+		.v_sync = 3,
+		.v_back = 19,
+		.v_sync_ln = 1,
+	},
+};
+
+static struct hdmi_format_para fmt_para_720x576i50_4x3 = {
+	.vic = HDMI_720x576i50_4x3,
+	.name = "720x576i50hz4x3",
+	.sname = "576i50hz4x3",
 	.pixel_repetition_factor = 1,
 	.progress_mode = 0,
 	.scrambler_en = 0,
@@ -1031,6 +1157,10 @@ static struct hdmi_format_para *all_fmt_paras[] = {
 	&fmt_para_720x480i60_16x9,
 	&fmt_para_720x576p50_16x9,
 	&fmt_para_720x576i50_16x9,
+	&fmt_para_720x480p60_4x3,
+	&fmt_para_720x480i60_4x3,
+	&fmt_para_720x576p50_4x3,
+	&fmt_para_720x576i50_4x3,
 	&fmt_para_3840x1080p100_16x9,
 	&fmt_para_3840x1080p120_16x9,
 	&fmt_para_3840x540p200_16x9,
@@ -1188,12 +1318,12 @@ struct hdmi_format_para *hdmi_get_fmt_name(char const *name, char const *attr)
 
 	for (i = 0; all_fmt_paras[i]; i++) {
 		lname = all_fmt_paras[i]->name;
-		if (lname && (strncmp(name, lname, strlen(lname)) == 0)) {
+		if (lname && (strncmp(name, lname, strlen(name)) == 0)) {
 			vic = all_fmt_paras[i]->vic;
 			break;
 		}
 		lname = all_fmt_paras[i]->sname;
-		if (lname && (strncmp(name, lname, strlen(lname)) == 0)) {
+		if (lname && (strncmp(name, lname, strlen(name)) == 0)) {
 			vic = all_fmt_paras[i]->vic;
 			break;
 		}


### PR DESCRIPTION
All mandatory modes from HDMI 1.4b are included.  Note AML filter out interlaced FP modes.