### PR TITLE
fix HDMI 3D flag signalling

### DIFF
--- a/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hdmi_tx_main.c
@@ -1433,8 +1433,8 @@ static ssize_t store_config(struct device *dev,
 			hdmitx_device.flag_3dtb = 0;
 			hdmitx_device.flag_3dss = 1;
 			hdmitx_device.flag_3dfp = 0;
-			if (buf[2])
-				ret = kstrtoul(buf+2, 10,
+			if (buf[4])
+				ret = kstrtoul(buf+4, 10,
 					&sub_sample_mode);
 			/* side by side */
 			hdmi_set_3d(&hdmitx_device, T3D_SBS_HALF,

--- a/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
+++ b/drivers/amlogic/hdmi/hdmi_tx_20/hw/hdmi_tx_hw.c
@@ -2057,9 +2057,9 @@ static void hdmitx_set_packet(int type, unsigned char *DB, unsigned char *HB)
 				hdmitx_wr_reg(HDMITX_DWC_FC_VSDSIZE, 6);
 		}
 		/* Enable VSI packet */
-		hdmitx_set_reg_bits(HDMITX_DWC_FC_DATAUTO0, 1, 3, 1);
 		hdmitx_wr_reg(HDMITX_DWC_FC_DATAUTO1, 0);
 		hdmitx_wr_reg(HDMITX_DWC_FC_DATAUTO2, 0x10);
+		hdmitx_set_reg_bits(HDMITX_DWC_FC_DATAUTO0, 1, 3, 1);
 		hdmitx_set_reg_bits(HDMITX_DWC_FC_PACKET_TX_EN, 1, 4, 1);
 		break;
 	case HDMI_PACKET_DRM:
@@ -4597,7 +4597,7 @@ static void config_hdmi20_tx(enum hdmi_vic vic,
 		}
 	}
 
-	if (hdev->flag_3dfp) {
+	if (hdev->flag_3dfp || hdev->flag_3dss || hdev->flag_3dtb) {
 		hdmitx_set_reg_bits(HDMITX_DWC_FC_DATAUTO0, 1, 3, 1);
 		hdmitx_set_reg_bits(HDMITX_DWC_FC_PACKET_TX_EN, 1, 4, 1);
 	 } else {


### PR DESCRIPTION
This fixes two problems:
* correctly parse the SBS sub-sampling part of the 3dss command
* signalling Half-SBS/TAB mode over HDMI