### PR TITLE
UHD output squeezed after MVC/FP video was played

### DIFF
--- a/drivers/amlogic/amports/video.c
+++ b/drivers/amlogic/amports/video.c
@@ -421,6 +421,7 @@ atomic_t capture_use_cnt = ATOMIC_INIT(CAPTURE_STATE_OFF);
 	do { \
 		CLEAR_VCBUS_REG_MASK(VPP_MISC + cur_dev->vpp_off, \
 		VPP_VD2_PREBLEND | (0x1ff << VPP_VD2_ALPHA_BIT)); \
+		VIDEO_LAYER2_OFF(); \
 		VD2_MEM_POWER_OFF(); \
 	} while (0)
 #endif
@@ -1117,7 +1118,6 @@ static void vpp_settings_h(struct vpp_frame_par_s *framePtr)
 			((framePtr->VPP_hsc_endp & VPP_VD_SIZE_MASK)
 			<< VPP_VD1_END_BIT));
 		} else{
-
 			VSYNC_WR_MPEG_REG(VPP_POSTBLEND_VD1_H_START_END +
 			cur_dev->vpp_off,
 			((framePtr->VPP_hsc_startp & VPP_VD_SIZE_MASK)

--- a/drivers/amlogic/amports/video.c
+++ b/drivers/amlogic/amports/video.c
@@ -1118,6 +1118,13 @@ static void vpp_settings_h(struct vpp_frame_par_s *framePtr)
 			((framePtr->VPP_hsc_endp & VPP_VD_SIZE_MASK)
 			<< VPP_VD1_END_BIT));
 		} else{
+			VSYNC_WR_MPEG_REG(VPP_PREBLEND_VD1_H_START_END +
+			cur_dev->vpp_off,
+			((framePtr->VPP_hd_start_lines_ &
+			VPP_VD_SIZE_MASK) << VPP_VD1_START_BIT) |
+			((framePtr->VPP_hd_end_lines_ &
+			VPP_VD_SIZE_MASK) << VPP_VD1_END_BIT));
+
 			VSYNC_WR_MPEG_REG(VPP_POSTBLEND_VD1_H_START_END +
 			cur_dev->vpp_off,
 			((framePtr->VPP_hsc_startp & VPP_VD_SIZE_MASK)


### PR DESCRIPTION
If either the MODE_3D_OUT_TB or the MODE_3D_OUT_LR flags are set, then the VPP_PREBLEND_VD1_H_START_END is set. But this setting is never reverted if the above mentioned flags are cleared. So the VPP_PREBLEND_VD1_H_START_END remains unchanged in that case.

The second problem solved here is, that the Video Layer 2 (needed in MVC/FP) is never really turned off even if DisableVideoLayer2() is called.

